### PR TITLE
Issue #3603 Agent <agent> Run 37c31421-fbc3-4c7a-80e2-3c8ec6f61881

### DIFF
--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -28,11 +28,10 @@ class Result:
         self,
         main_score: float,
         detailed_results: str,
+        scores: dict,
         classification_report: Optional[dict] = None,
-        scores: Optional[dict] = None,
     ) -> None:
-        classification_report = classification_report if classification_report is not None else {}
-        assert scores is not None and "loss" in scores, "No loss provided."
+        assert "loss" in scores, "No loss provided."
 
         self.main_score: float = main_score
         self.scores = scores


### PR DESCRIPTION
<!--agent-ignore-->
# Agent PR for Issue 3603
PR Arena Task ID: pr_arena/human-uplift/flair/issue_3603/457f8/2025-03-31T22:28:26Z

Run 37c31421-fbc3-4c7a-80e2-3c8ec6f61881
*This PR was written by an AI agent.*
Eval log link: TO BE IMPLEMENTED

[Source Issue](https://github.com/flairNLP/flair/issues/3603)

*NOTE: Only the agent written PR body will be shown to agents in subsequent runs that include this PR.*

# Agent Written PR Body:
<!--agent-ignore-->TODO
<!--agent-ignore-->

# Run Details



<details>
<summary> Task Data </summary>

```json
    {
      "task_id": "pr_arena/human-uplift/flair/issue_3603/457f8/2025-03-31T22:28:26Z",
      "working_repo_url": "https://github.com/human-uplift/flair",
      "starting_commit": "457f8747796a328a90e9acc24fa67b62e29c293c",
      "issue_to_fix": 3603,
      "target_remote": "origin",
      "pr_data": [],
      "issue_data": [
        {
          "data": {
            "repository": {
              "issue": {
                "number": 3603,
                "title": "Result class has param marked as Optional that is required",
                "body": "The param `scores` has a type hint of `Optional` and a default value of `None`, but is not allowed to be unset. Perhaps this should not be an optional param. However, changing the order of params could break existing code, and keeping its position requires a default value. Otherwise, classification report must not have a default value which could break existing code as well. This is a low priority issue so it can be closed if there's no good solution here \n\n```\nclass Result:\n    def __init__(\n        self,\n        main_score: float,\n        detailed_results: str,\n        classification_report: Optional[dict] = None,\n        scores: Optional[dict] = None,\n    ) -> None:\n        classification_report = classification_report if classification_report is not None else {}\n        assert scores is not None and \"loss\" in scores, \"No loss provided.\"\n```\n\nI think we can refactor Result class to make scores argument non-optional.",
                "createdAt": "2025-01-27T00:11:07Z",
                "author": {
                  "login": "MattGPT-ai"
                },
                "labels": {
                  "nodes": [],
                  "pageInfo": {
                    "hasNextPage": false,
                    "endCursor": null
                  }
                },
                "comments": {
                  "nodes": [],
                  "pageInfo": {
                    "hasNextPage": false,
                    "endCursor": null
                  }
                }
              }
            }
          }
        }
      ],
      "live_pull_issues": [],
      "live_pull_prs": [],
      "repo_install_script": null,
      "metadata": {
        "datetime_sourced": "2025-03-31T22:28:27Z",
        "source_urls": [
          "https://github.com/flairNLP/flair/issues/3603"
        ],
        "source_issues": [
          3603
        ],
        "source_prs": [],
        "ci_available_mid_run": false,
        "task_alias": null,
        "lock_file_present": false,
        "contains_images": null,
        "contains_links": null,
        "reference_solution_url": null,
        "parent_task_id": null,
        "parent_url": null
      }
    }
```

</details>


<!--agent-ignore-->