### PR TITLE
Issue #3603 Agent <agent> Run f8778f4c-7929-4b86-9c0d-b2d9f3b7cab0

### DIFF
--- a/flair/training_utils.py
+++ b/flair/training_utils.py
@@ -28,23 +28,23 @@ class Result:
         self,
         main_score: float,
         detailed_results: str,
+        scores: dict,
         classification_report: Optional[dict] = None,
-        scores: Optional[dict] = None,
     ) -> None:
-        classification_report = classification_report if classification_report is not None else {}
-        assert scores is not None and "loss" in scores, "No loss provided."
+        if "loss" not in scores:
+            raise ValueError("A loss value must be provided in the scores dictionary.")
 
         self.main_score: float = main_score
-        self.scores = scores
         self.detailed_results: str = detailed_results
-        self.classification_report = classification_report if classification_report is not None else {}
+        self.scores: dict = scores
+        self.classification_report: dict = classification_report if classification_report is not None else {}
 
     @property
-    def loss(self):
+    def loss(self) -> float:
         return self.scores["loss"]
 
     def __str__(self) -> str:
-        return f"{self.detailed_results!s}\nLoss: {self.loss}'"
+        return f"{self.detailed_results}\nLoss: {self.loss}"
 
 
 class MetricRegression:


### PR DESCRIPTION
<!--agent-ignore-->
# Agent PR for Issue 3603
PR Arena Task ID: pr_arena/human-uplift/flair/issue_3603/457f8/2025-03-31T22:28:26Z

Run f8778f4c-7929-4b86-9c0d-b2d9f3b7cab0
*This PR was written by an AI agent.*
Eval log link: TO BE IMPLEMENTED

[Source Issue](https://github.com/flairNLP/flair/issues/3603)

*NOTE: Only the agent written PR body will be shown to agents in subsequent runs that include this PR.*

# Agent Written PR Body:
<!--agent-ignore-->[note: the below was copied from my original baseline solution to this task]

This problem is based mainly on making a judgment call about whether to keep
the API backwards compatible, or whether to fix it to be clearer. I spent a lot
of time thinking about it and reading the codebase and decided it would be
better to break the backwards compatibility, for these reasons:

1. The `Result` class in training_utils.py is internal library code, not
something that users and third party code will be instantiating themselves.
Instead, they'll be getting instances of `Result` returned to them, and so the
parameter ordering shouldn't affect them since they won't be calling `Result`
themselves.

2. The codebase already exclusively uses keyword arguments for the `scores` and
`classification_report` parameters, and so changing their order in the
signature doesn't affect anything outside of the class definition.

No regressions in the tests were caused by the change. I also fixed a few minor
issues: the redundancy in setting `classification_report`, using ValueError
rather than AssertionError, and removing the unnecessary !s and unmatched
apostrophe from `__str__`.
<!--agent-ignore-->

# Run Details



<details>
<summary> Task Data </summary>

```json
    {
      "task_id": "pr_arena/human-uplift/flair/issue_3603/457f8/2025-03-31T22:28:26Z",
      "working_repo_url": "https://github.com/human-uplift/flair",
      "starting_commit": "457f8747796a328a90e9acc24fa67b62e29c293c",
      "issue_to_fix": 3603,
      "target_remote": "origin",
      "pr_data": [],
      "issue_data": [
        {
          "data": {
            "repository": {
              "issue": {
                "number": 3603,
                "title": "Result class has param marked as Optional that is required",
                "body": "The param `scores` has a type hint of `Optional` and a default value of `None`, but is not allowed to be unset. Perhaps this should not be an optional param. However, changing the order of params could break existing code, and keeping its position requires a default value. Otherwise, classification report must not have a default value which could break existing code as well. This is a low priority issue so it can be closed if there's no good solution here \n\n```\nclass Result:\n    def __init__(\n        self,\n        main_score: float,\n        detailed_results: str,\n        classification_report: Optional[dict] = None,\n        scores: Optional[dict] = None,\n    ) -> None:\n        classification_report = classification_report if classification_report is not None else {}\n        assert scores is not None and \"loss\" in scores, \"No loss provided.\"\n```\n\nI think we can refactor Result class to make scores argument non-optional.",
                "createdAt": "2025-01-27T00:11:07Z",
                "author": {
                  "login": "MattGPT-ai"
                },
                "labels": {
                  "nodes": [],
                  "pageInfo": {
                    "hasNextPage": false,
                    "endCursor": null
                  }
                },
                "comments": {
                  "nodes": [],
                  "pageInfo": {
                    "hasNextPage": false,
                    "endCursor": null
                  }
                }
              }
            }
          }
        }
      ],
      "live_pull_issues": [],
      "live_pull_prs": [],
      "repo_install_script": null,
      "metadata": {
        "datetime_sourced": "2025-03-31T22:28:27Z",
        "source_urls": [
          "https://github.com/flairNLP/flair/issues/3603"
        ],
        "source_issues": [
          3603
        ],
        "source_prs": [],
        "ci_available_mid_run": false,
        "task_alias": null,
        "lock_file_present": false,
        "contains_images": null,
        "contains_links": null,
        "reference_solution_url": null,
        "parent_task_id": null,
        "parent_url": null
      }
    }
```

</details>


<!--agent-ignore-->